### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/common/mule-ee-bom/pom.xml
+++ b/common/mule-ee-bom/pom.xml
@@ -25,7 +25,7 @@
         <activemq-all.version>5.10.0</activemq-all.version>
 
         <!-- utilities -->
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-lang.version>2.6</commons-lang.version>
 
         <!-- Mule EE license for testing -->


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
